### PR TITLE
Fix code scanning alert no. 13: Uncontrolled command line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,25 +93,33 @@ autoUpdater.on('update-downloaded', (info) => {
 const download=(parameter)=>{
   fs.appendFileSync(path.join(app.getPath('userData'),'historic.txt'),`${parameter}\n`)
   var msg;
-  const command = `${app.getPath('userData')}\\ytdlp -vU --write-info-json  --remux mp4 ${parameter} -f "bv*+ba/b" --write-playlist-metafiles --parse-metadata "playlist_title:.+ - (?P<folder_name>Videos|Shorts|Live)$" -o "${app.getPath('userData')}/file/%(channel|)s-%(folder_name|)s-%(title)s [%(id)s].%(ext)s" 
-`;
-    const child = require('child_process');
-    const childProcess = child.spawn(command, { shell: true });
-    childProcess.stdout.on('data', (data) => {
-      msg = `stdout: ${data}`;
+  const args = [
+    '-vU',
+    '--write-info-json',
+    '--remux', 'mp4',
+    parameter,
+    '-f', 'bv*+ba/b',
+    '--write-playlist-metafiles',
+    '--parse-metadata', 'playlist_title:.+ - (?P<folder_name>Videos|Shorts|Live)$',
+    '-o', `${app.getPath('userData')}/file/%(channel|)s-%(folder_name|)s-%(title)s [%(id)s].%(ext)s`
+  ];
+  const child = require('child_process');
+  const childProcess = child.spawn(`${app.getPath('userData')}\\ytdlp`, args);
+  childProcess.stdout.on('data', (data) => {
+    msg = `stdout: ${data}`;
     //  log.info(msg);
-    });
-    childProcess.stderr.on('data', (data) => {
-      msg = `stderr: ${data}`;
-   //   log.info(msg);
-    });
-    childProcess.on('close', (code) => {
-      if (code !== 0) {
-        msg = `exec error: ${code}`;
-   //    log.info(msg);
-      }
-    });
-    return msg
+  });
+  childProcess.stderr.on('data', (data) => {
+    msg = `stderr: ${data}`;
+    //   log.info(msg);
+  });
+  childProcess.on('close', (code) => {
+    if (code !== 0) {
+      msg = `exec error: ${code}`;
+      //    log.info(msg);
+    }
+  });
+  return msg
 }
 const downloaddata=(parameter)=>{
   fs.appendFileSync(path.join(app.getPath('userData'),'historic.txt'),`${parameter}\n`)


### PR DESCRIPTION
Fixes [https://github.com/alphaleadership/youtube-public/security/code-scanning/13](https://github.com/alphaleadership/youtube-public/security/code-scanning/13)

To fix the problem, we should avoid using `child_process.spawn` with `shell: true` and instead use `child_process.spawn` or `child_process.execFile` with an array of arguments. This approach prevents command injection by treating each argument as a separate entity, rather than concatenating them into a single command string. We will need to parse the `parameter` into an array of arguments and pass it to `spawn` or `execFile`.

1. Replace the construction of the `command` string with an array of arguments.
2. Use `child_process.spawn` or `child_process.execFile` with the array of arguments.
3. Ensure that the `parameter` is properly sanitized or validated before use.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
