### PR TITLE
Fix code scanning alert no. 11: Missing rate limiting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,12 @@ const { autoUpdater } = require("electron-updater")
 const express = require('express');
 const RateLimit = require('express-rate-limit');
 const fs = require('fs');
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
 const https = require('https');
 
 const path = require('path');
@@ -369,7 +375,7 @@ web.get("/renderer.js",function (req, res) {
   res.statusCode=200
   res.send(fs.readFileSync(path.join(app.getPath('userData'), "./src/renderer.js"))) // Correction pour utiliser path.join pour une construction de chemin valide
 })
-web.get("/video", function (req, res) {
+web.get("/video", limiter, function (req, res) {
   log.info(req.query)  
   log.info(req.headers)
   // Ensure there is a range given for the video


### PR DESCRIPTION
Fixes [https://github.com/alphaleadership/youtube-public/security/code-scanning/11](https://github.com/alphaleadership/youtube-public/security/code-scanning/11)

To fix the problem, we need to introduce a rate-limiting middleware to the Express application. This can be achieved by using the `express-rate-limit` package. We will set up a rate limiter that restricts the number of requests a client can make to the `/video` endpoint within a specified time window. This will help mitigate the risk of denial-of-service attacks by limiting the rate at which requests are accepted.

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the `src/index.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum number of requests per minute).
4. Apply the rate limiter to the `/video` endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
